### PR TITLE
Add support for sub-state machines

### DIFF
--- a/Framework/Editor/V0/Aac.cs
+++ b/Framework/Editor/V0/Aac.cs
@@ -216,12 +216,12 @@ namespace AnimatorAsCode.V0
             return this;
         }
 
-        public void WithAvatarMaskNoTransforms()
+        public AvatarMask WithAvatarMaskNoTransforms()
         {
-            ResolveAvatarMask(new Transform[0]);
+            return ResolveAvatarMask(new Transform[0]);
         }
 
-        public void ResolveAvatarMask(Transform[] paths)
+        public AvatarMask ResolveAvatarMask(Transform[] paths)
         {
             // FIXME: Fragile
             var avatarMask = new AvatarMask();
@@ -253,6 +253,7 @@ namespace AnimatorAsCode.V0
             AssetDatabase.AddObjectToAsset(avatarMask, _animatorController);
 
             WithAvatarMask(avatarMask);
+            return avatarMask;
         }
     }
 

--- a/Framework/Editor/V0/Aac.cs
+++ b/Framework/Editor/V0/Aac.cs
@@ -95,9 +95,9 @@ namespace AnimatorAsCode.V0
         private readonly AnimatorController _animatorController;
         private readonly AacConfiguration _configuration;
         private readonly string _fullLayerName;
-        private readonly AacStateMachine _stateMachine;
+        private readonly AacFlStateMachine _stateMachine;
 
-        internal AacFlLayer(AnimatorController animatorController, AacConfiguration configuration, AacStateMachine stateMachine, string fullLayerName)
+        internal AacFlLayer(AnimatorController animatorController, AacConfiguration configuration, AacFlStateMachine stateMachine, string fullLayerName)
         {
             _animatorController = animatorController;
             _configuration = configuration;
@@ -107,7 +107,7 @@ namespace AnimatorAsCode.V0
 
         public AacFlState NewState(string name)
         {
-            var lastState = _stateMachine.LastStatePosition();
+            var lastState = _stateMachine.LastNodePosition();
             var state = _stateMachine.NewState(name, 0, 0).Shift(lastState, 0, 1);
             return state;
         }
@@ -117,12 +117,27 @@ namespace AnimatorAsCode.V0
             return _stateMachine.NewState(name, x, y);
         }
 
+        public AacFlStateMachine NewStateMachine(string name)
+        {
+            return _stateMachine.NewStateMachine(name);
+        }
+
+        public AacFlStateMachine NewStateMachine(string name, int x, int y)
+        {
+            return _stateMachine.NewStateMachine(name, x, y);
+        }
+
         public AacFlTransition AnyTransitionsTo(AacFlState destination)
         {
             return _stateMachine.AnyTransitionsTo(destination);
         }
 
         public AacFlEntryTransition EntryTransitionsTo(AacFlState destination)
+        {
+            return _stateMachine.EntryTransitionsTo(destination);
+        }
+        
+        public AacFlEntryTransition EntryTransitionsTo(AacFlStateMachine destination)
         {
             return _stateMachine.EntryTransitionsTo(destination);
         }
@@ -548,7 +563,7 @@ namespace AnimatorAsCode.V0
         }
 
         // DEPRECATED: This causes the editor window to glitch by deselecting, which is jarring for experimentation
-        internal AacStateMachine CreateOrRemakeLayerAtSameIndex(string layerName, float weightWhenCreating, AvatarMask maskWhenCreating = null)
+        internal AacFlStateMachine CreateOrRemakeLayerAtSameIndex(string layerName, float weightWhenCreating, AvatarMask maskWhenCreating = null)
         {
             var originalIndexToPreserveOrdering = FindIndexOf(layerName);
             if (originalIndexToPreserveOrdering != -1)
@@ -567,14 +582,14 @@ namespace AnimatorAsCode.V0
             }
 
             var layer = TryGetLayer(layerName);
-            var machinist = new AacStateMachine(layer.stateMachine, _emptyClip, new AacBackingAnimator(this), _defaultsProvider);
+            var machinist = new AacFlStateMachine(layer.stateMachine, _emptyClip, new AacBackingAnimator(this), _defaultsProvider);
             return machinist
                 .WithAnyStatePosition(0, 7)
                 .WithEntryPosition(0, -1)
                 .WithExitPosition(7, -1);
         }
 
-        internal AacStateMachine CreateOrClearLayerAtSameIndex(string layerName, float weightWhenCreating, AvatarMask maskWhenCreating = null)
+        internal AacFlStateMachine CreateOrClearLayerAtSameIndex(string layerName, float weightWhenCreating, AvatarMask maskWhenCreating = null)
         {
             var originalIndexToPreserveOrdering = FindIndexOf(layerName);
             if (originalIndexToPreserveOrdering != -1)
@@ -602,7 +617,7 @@ namespace AnimatorAsCode.V0
             _animatorController.layers = layers;
 
             var layer = TryGetLayer(layerName);
-            var machinist = new AacStateMachine(layer.stateMachine, _emptyClip, new AacBackingAnimator(this), _defaultsProvider);
+            var machinist = new AacFlStateMachine(layer.stateMachine, _emptyClip, new AacBackingAnimator(this), _defaultsProvider);
             return machinist
                 .WithAnyStatePosition(0, 7)
                 .WithEntryPosition(0, -1)

--- a/Framework/Editor/V0/AacAnimatorNode.cs
+++ b/Framework/Editor/V0/AacAnimatorNode.cs
@@ -1,6 +1,4 @@
 using UnityEngine;
-using UnityEditor.Animations;
-using System.Linq;
 
 namespace AnimatorAsCode.V0
 {

--- a/Framework/Editor/V0/AacAnimatorNode.cs
+++ b/Framework/Editor/V0/AacAnimatorNode.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEditor.Animations;
+using System.Linq;
+
+namespace AnimatorAsCode.V0
+{
+    public abstract class AacAnimatorNode
+    {
+        protected internal abstract Vector3 GetPosition();
+        protected internal abstract void SetPosition(Vector3 position);
+    }
+    
+    public abstract class AacAnimatorNode<T> : AacAnimatorNode where T: AacAnimatorNode<T>
+    {
+        protected readonly AacFlStateMachine ParentMachine;
+        protected readonly IAacDefaultsProvider DefaultsProvider;
+
+        protected AacAnimatorNode(AacFlStateMachine parentMachine, IAacDefaultsProvider defaultsProvider)
+        {
+            ParentMachine = parentMachine;
+            DefaultsProvider = defaultsProvider;
+        }
+
+        public T LeftOf(T otherNode) => MoveNextTo(otherNode, -1, 0);
+        public T RightOf(T otherNode) => MoveNextTo(otherNode, 1, 0);
+        public T Over(T otherNode) => MoveNextTo(otherNode, 0, -1);
+        public T Under(T otherNode) => MoveNextTo(otherNode, 0, 1);
+
+        public T LeftOf() => MoveNextTo(null, -1, 0);
+        public T RightOf() => MoveNextTo(null, 1, 0);
+        public T Over() => MoveNextTo(null, 0, -1);
+        public T Under() => MoveNextTo(null, 0, 1);
+        
+        public T Shift(T otherState, int shiftX, int shiftY) => MoveNextTo(otherState, shiftX, shiftY);
+        
+        private T MoveNextTo(T otherStateOrSecondToLastWhenNull, int x, int y)
+        {
+            if (otherStateOrSecondToLastWhenNull == null)
+            {
+                var siblings = ParentMachine.GetChildNodes();
+                var other = siblings[siblings.Count - 2];
+                Shift(other.GetPosition(), x, y);
+
+                return (T) this;
+            }
+
+            Shift(otherStateOrSecondToLastWhenNull.GetPosition(), x, y);
+            
+            return (T) this;
+        }
+
+        public T Shift(Vector3 otherPosition, int shiftX, int shiftY)
+        {
+            SetPosition(otherPosition + new Vector3(shiftX * DefaultsProvider.Grid().x, shiftY * DefaultsProvider.Grid().y, 0));
+            return (T) this;
+        }
+    }
+}

--- a/Framework/Editor/V0/AacAnimatorNode.cs.meta
+++ b/Framework/Editor/V0/AacAnimatorNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d998de0b1f138034c9b9237055cd03ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Framework/Editor/V0/AacFlStates.cs
+++ b/Framework/Editor/V0/AacFlStates.cs
@@ -247,7 +247,7 @@ namespace AnimatorAsCode.V0
 
         internal Vector3 LastNodePosition()
         {
-            return _childNodes.LastOrDefault()?.GetPosition() ?? Vector3.zero;
+            return _childNodes.LastOrDefault()?.GetPosition() ?? Vector3.right * _gridShiftX * 2;
         }
 
         private Vector3 GridPosition(int x, int y)

--- a/Framework/Editor/V0/AacFlStates.cs
+++ b/Framework/Editor/V0/AacFlStates.cs
@@ -206,7 +206,6 @@ namespace AnimatorAsCode.V0
             return EntryTransition(this, ParentMachine.Machine);
         }
         
-        
         public AacFlNewTransitionContinuation TransitionsTo(AacFlState destination)
         {
             return new AacFlNewTransitionContinuation(ParentMachine.Machine.AddStateMachineTransition(Machine, destination.State), ParentMachine.Machine, Machine, destination.State);
@@ -215,6 +214,11 @@ namespace AnimatorAsCode.V0
         public AacFlNewTransitionContinuation TransitionsTo(AacFlStateMachine destination)
         {
             return new AacFlNewTransitionContinuation(ParentMachine.Machine.AddStateMachineTransition(Machine, destination.Machine), ParentMachine.Machine, Machine, destination.Machine);
+        }
+        
+        public AacFlNewTransitionContinuation Restarts()
+        {
+            return new AacFlNewTransitionContinuation(ParentMachine.Machine.AddStateMachineTransition(Machine, Machine), ParentMachine.Machine, Machine, Machine);
         }
         
         public AacFlNewTransitionContinuation Exits()

--- a/Framework/Editor/V0/AacFlStates.cs
+++ b/Framework/Editor/V0/AacFlStates.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using UnityEditor.Animations;
 using UnityEngine;
-using UnityEngine.UIElements;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase;
 
@@ -647,7 +645,7 @@ namespace AnimatorAsCode.V0
     {
         private readonly AnimatorStateTransition _transition;
 
-        public AacFlTransition(AnimatorStateTransition transition, AnimatorStateMachine machine, AacFlTransitionEndpoint sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
+        public AacFlTransition(AnimatorStateTransition transition, AnimatorStateMachine machine, AacTransitionEndpoint sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
         {
             _transition = transition;
         }
@@ -715,7 +713,7 @@ namespace AnimatorAsCode.V0
 
     public class AacFlEntryTransition : AacFlNewTransitionContinuation
     {
-        public AacFlEntryTransition(AnimatorTransition transition, AnimatorStateMachine machine, AnimatorState sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
+        public AacFlEntryTransition(AnimatorTransition transition, AnimatorStateMachine machine, AnimatorState sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
         {
         }
     }
@@ -750,10 +748,10 @@ namespace AnimatorAsCode.V0
     {
         public readonly AnimatorTransitionBase Transition;
         private readonly AnimatorStateMachine _machine;
-        private readonly AacFlTransitionEndpoint _sourceNullableIfAny;
-        private readonly AacFlTransitionEndpoint _destinationNullableIfExits;
+        private readonly AacTransitionEndpoint _sourceNullableIfAny;
+        private readonly AacTransitionEndpoint _destinationNullableIfExits;
 
-        public AacFlNewTransitionContinuation(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacFlTransitionEndpoint sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits)
+        public AacFlNewTransitionContinuation(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacTransitionEndpoint sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits)
         {
             Transition = transition;
             _machine = machine;
@@ -834,7 +832,7 @@ namespace AnimatorAsCode.V0
 
     public class AacFlTransitionContinuation : AacFlTransitionContinuationAbstractWithOr
     {
-        public AacFlTransitionContinuation(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacFlTransitionEndpoint sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
+        public AacFlTransitionContinuation(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacTransitionEndpoint sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
         {
         }
 
@@ -874,7 +872,7 @@ namespace AnimatorAsCode.V0
     {
         private readonly List<AacFlTransitionContinuation> _pendingContinuations;
 
-        public AacFlMultiTransitionContinuation(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacFlTransitionEndpoint sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits, List<AacFlTransitionContinuation> pendingContinuations) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
+        public AacFlMultiTransitionContinuation(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacTransitionEndpoint sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits, List<AacFlTransitionContinuation> pendingContinuations) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
         {
             _pendingContinuations = pendingContinuations;
         }
@@ -921,7 +919,7 @@ namespace AnimatorAsCode.V0
 
     public class AacFlTransitionContinuationOnlyOr : AacFlTransitionContinuationAbstractWithOr
     {
-        public AacFlTransitionContinuationOnlyOr(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacFlTransitionEndpoint sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
+        public AacFlTransitionContinuationOnlyOr(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacTransitionEndpoint sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits) : base(transition, machine, sourceNullableIfAny, destinationNullableIfExits)
         {
         }
     }
@@ -930,10 +928,10 @@ namespace AnimatorAsCode.V0
     {
         protected readonly AnimatorTransitionBase Transition;
         private readonly AnimatorStateMachine _machine;
-        private readonly AacFlTransitionEndpoint _sourceNullableIfAny;
-        private readonly AacFlTransitionEndpoint _destinationNullableIfExits;
+        private readonly AacTransitionEndpoint _sourceNullableIfAny;
+        private readonly AacTransitionEndpoint _destinationNullableIfExits;
 
-        public AacFlTransitionContinuationAbstractWithOr(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacFlTransitionEndpoint sourceNullableIfAny, AacFlTransitionEndpoint destinationNullableIfExits)
+        public AacFlTransitionContinuationAbstractWithOr(AnimatorTransitionBase transition, AnimatorStateMachine machine, AacTransitionEndpoint sourceNullableIfAny, AacTransitionEndpoint destinationNullableIfExits)
         {
             Transition = transition;
             _machine = machine;
@@ -1069,29 +1067,29 @@ namespace AnimatorAsCode.V0
         }
     }
     
-    public class AacFlTransitionEndpoint
+    public class AacTransitionEndpoint
     {
         private readonly AnimatorState _state;
         private readonly AnimatorStateMachine _stateMachine;
 
-        public AacFlTransitionEndpoint([NotNull] AnimatorState state)
+        public AacTransitionEndpoint(AnimatorState state)
         {
             _state = state;
         }
         
-        public AacFlTransitionEndpoint([NotNull] AnimatorStateMachine stateMachine)
+        public AacTransitionEndpoint(AnimatorStateMachine stateMachine)
         {
             _stateMachine = stateMachine;
         }
 
-        public static implicit operator AacFlTransitionEndpoint([NotNull] AnimatorState state)
+        public static implicit operator AacTransitionEndpoint(AnimatorState state)
         {
-            return new AacFlTransitionEndpoint(state);
+            return new AacTransitionEndpoint(state);
         }
         
-        public static implicit operator AacFlTransitionEndpoint([NotNull] AnimatorStateMachine stateMachine)
+        public static implicit operator AacTransitionEndpoint(AnimatorStateMachine stateMachine)
         {
-            return new AacFlTransitionEndpoint(stateMachine);
+            return new AacTransitionEndpoint(stateMachine);
         }
 
         public bool TryGetState(out AnimatorState state)


### PR DESCRIPTION
Hello and thanks for this wonderful tool!

In this PR, I've added a new base class for `AacFlState` and `AacFlStateMachine` called `AacAnimatorNode<T>` which contains common code, such as placement of nodes.

Child nodes of an `AacFlStateMachine` are stored in `_childNodes` upon creation, so that node layout between state and state machines is consistent.

`AacTransitionEndpoint` is now used for sources & destinations of transition wrappers. This can contain either an `AnimatorState` or `AnimatorStateMachine`. It is expected that if the `AacTransitionEndpoint` is not null then one of its members will also not be null; this is checked using exceptions.

Syntax for StateMachines the same as for States:

```c#
var l = aac.CreateSupportingFxLayer("Face");
l.WithAvatarMaskNoTransforms();

var moodMachine = l.NewStateMachine("Default");
moodMachine.TransitionsFromEntry().When(moodParam.IsEqualTo(0));
moodMachine.Exits().When(moodParam.IsNotEqualTo(0));

var state = moodMachine.NewState("Default");
state.TransitionsFromEntry().When(...);
state.Exits().WithTransitionDurationSeconds(transitionTime).When(...);
```

Also changed `ResolveAvatarMask` and `WithAvatarMaskNoTransforms` functions (since they were void) to return the `AvatarMask` created so that the user can edit / re-use it further without much hassle.

Please let me know what you think.