### PR TITLE
AvatarMaskBodyPart support for ResolveAvatarMask

### DIFF
--- a/Framework/Editor/V0/Aac.cs
+++ b/Framework/Editor/V0/Aac.cs
@@ -205,8 +205,18 @@ namespace AnimatorAsCode.V0
         {
             ResolveAvatarMask(new Transform[0]);
         }
-
+        
+        public void ResolveAvatarMask(AvatarMaskBodyPart[] bodyParts)
+        {
+            ResolveAvatarMask(new Transform[0], bodyParts);
+        }
+        
         public void ResolveAvatarMask(Transform[] paths)
+        {
+            ResolveAvatarMask(paths, new AvatarMaskBodyPart[0]);
+        }
+
+        public void ResolveAvatarMask(Transform[] paths, AvatarMaskBodyPart[] bodyParts)
         {
             // FIXME: Fragile
             var avatarMask = new AvatarMask();
@@ -232,7 +242,7 @@ namespace AnimatorAsCode.V0
 
             for (int i = 0; i < (int) AvatarMaskBodyPart.LastBodyPart; i++)
             {
-                avatarMask.SetHumanoidBodyPartActive((AvatarMaskBodyPart) i, false);
+                avatarMask.SetHumanoidBodyPartActive((AvatarMaskBodyPart) i, bodyParts.Contains((AvatarMaskBodyPart)i));
             }
 
             AssetDatabase.AddObjectToAsset(avatarMask, _animatorController);


### PR DESCRIPTION
`ResolveAvatarMask` is really powerful, but the fact that it does not allow combining `AvatarMaskBodyPart`s with transforms makes it a lot less useful.

My use case being the gesture layer. Say you have left hand, right hand, left ear and right ear layers.

The hand layers can be simply done via `VrcAssets()` and the ear layers can also be simply done with `ResolveAvatarMask`.

However, as we know, the first layer of the gesture controller needs to union the masks of all sub-layers, so now we need a mask, which contains the ear transforms, as well as the fingers as `AvatarMaskBodyPart`.

This PR aims to add a way to easily achieve this without forcing the user to manually create the `AvatarMask`, while maintaining functionality on existing overloads.

```
var bodyParts = new[] { AvatarMaskBodyPart.LeftFingers, AvatarMaskBodyPart.RightFingers };
var earTransforms = new[] { leftEar, rightEar };

var firstLayer = aac.CreateMainGestureLayer();
firstLayer.ResolveAvatarMask(earTransforms, bodyParts);
```