### PR TITLE
`driver-copy`: Add bool support for DrivingCopies/DrivingRemaps/DrivingCasts

### DIFF
--- a/Framework/Editor/V0/AacFlStates.cs
+++ b/Framework/Editor/V0/AacFlStates.cs
@@ -529,6 +529,19 @@ namespace AnimatorAsCode.V0
             return this;
         }
 
+        public AacFlState DrivingCopies(AacFlBoolParameter source, AacFlBoolParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
         public AacFlState DrivingRemaps(AacFlIntParameter source, int sourceMin, int sourceMax, AacFlIntParameter destination, int destinationMin, int destinationMax)
         {
             CreateDriverBehaviorIfNotExists();
@@ -563,6 +576,101 @@ namespace AnimatorAsCode.V0
             return this;
         }
 
+        public AacFlState DrivingRemaps(AacFlBoolParameter source, float sourceMin, float sourceMax, AacFlBoolParameter destination, float destinationMin, float destinationMax)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = true,
+                sourceMin = sourceMin,
+                sourceMax = sourceMax,
+                destMin = destinationMin,
+                destMax = destinationMax
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlFloatParameter source, AacFlIntParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlIntParameter source, AacFlFloatParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlBoolParameter source, AacFlFloatParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlFloatParameter source, AacFlBoolParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlBoolParameter source, AacFlIntParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlIntParameter source, AacFlBoolParameter destination)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = false
+            });
+            return this;
+        }
+
         public AacFlState DrivingCasts(AacFlFloatParameter source, float sourceMin, float sourceMax, AacFlIntParameter destination, int destinationMin, int destinationMax)
         {
             CreateDriverBehaviorIfNotExists();
@@ -581,6 +689,74 @@ namespace AnimatorAsCode.V0
         }
 
         public AacFlState DrivingCasts(AacFlIntParameter source, int sourceMin, int sourceMax, AacFlFloatParameter destination, float destinationMin, float destinationMax)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = true,
+                sourceMin = sourceMin,
+                sourceMax = sourceMax,
+                destMin = destinationMin,
+                destMax = destinationMax
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlBoolParameter source, float sourceMin, float sourceMax, AacFlFloatParameter destination, float destinationMin, float destinationMax)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = true,
+                sourceMin = sourceMin,
+                sourceMax = sourceMax,
+                destMin = destinationMin,
+                destMax = destinationMax
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlFloatParameter source, float sourceMin, float sourceMax, AacFlBoolParameter destination, float destinationMin, float destinationMax)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = true,
+                sourceMin = sourceMin,
+                sourceMax = sourceMax,
+                destMin = destinationMin,
+                destMax = destinationMax
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlBoolParameter source, float sourceMin, float sourceMax, AacFlIntParameter destination, int destinationMin, int destinationMax)
+        {
+            CreateDriverBehaviorIfNotExists();
+            _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+            {
+                type = VRC_AvatarParameterDriver.ChangeType.Copy,
+                source = source.Name,
+                name = destination.Name,
+                convertRange = true,
+                sourceMin = sourceMin,
+                sourceMax = sourceMax,
+                destMin = destinationMin,
+                destMax = destinationMax
+            });
+            return this;
+        }
+
+        public AacFlState DrivingCasts(AacFlIntParameter source, int sourceMin, int sourceMax, AacFlBoolParameter destination, float destinationMin, float destinationMax)
         {
             CreateDriverBehaviorIfNotExists();
             _driver.parameters.Add(new VRC_AvatarParameterDriver.Parameter


### PR DESCRIPTION
Adds support for arguments of AacFlBoolParameter for DrivingCopies (bool -> bool), DrivingRemaps (bool <-> bool, bool <-> int, and bool <-> float), and DrivingCasts (bool <-> bool, bool <-> int, and bool <-> float) methods. 

This change provides complete support for the driver copy behavior capabilities. 