### PR TITLE
include LICENSE.meta

### DIFF
--- a/Packages/dev.hai-vr.animator-as-code.v1/.gitignore
+++ b/Packages/dev.hai-vr.animator-as-code.v1/.gitignore
@@ -30,5 +30,4 @@ Assembly-CSharp-Editor.csproj
 cfe-project.sln.DotSettings.user
 VRC.SDKBase.Editor.BuildPipeline.csproj
 VRC.SDKBase.Editor.ShaderStripping.csproj
-LICENSE.meta
 README.md.meta

--- a/Packages/dev.hai-vr.animator-as-code.v1/.gitignore
+++ b/Packages/dev.hai-vr.animator-as-code.v1/.gitignore
@@ -30,4 +30,3 @@ Assembly-CSharp-Editor.csproj
 cfe-project.sln.DotSettings.user
 VRC.SDKBase.Editor.BuildPipeline.csproj
 VRC.SDKBase.Editor.ShaderStripping.csproj
-README.md.meta

--- a/Packages/dev.hai-vr.animator-as-code.v1/V1/Editor/LICENSE.meta
+++ b/Packages/dev.hai-vr.animator-as-code.v1/V1/Editor/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c04d39cdc2e2392a5b51bfa466760178
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
generally all meta files should be included. 
For immutable packages like from package registries (e.g. OpenUPM) this is required, as unity can't write a new meta file into the immutable directory. 
Therefore any files without a meta file will break. Luckily this is just the LICENSE file, no code. But unity still complains.

closes #54 